### PR TITLE
Use PrintJobState correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ try {
         reject(/**/);
         return;
       }
-      if (jobState === PrintJobState.COMPLETED) {
+      if (jobState === "completed") {
         console.log("Job complete!");
         resolve(/**/);
         return;


### PR DESCRIPTION
This fixes the submitting a print job code snippet. `PrintJobState` is just a string on the JS side, not an enum.

Re #20.